### PR TITLE
bugFix extract block

### DIFF
--- a/chatblade/printer.py
+++ b/chatblade/printer.py
@@ -85,7 +85,13 @@ def contains_block(str):
 
 def extract_block(str):
     matches = re.findall(r"```(.*?)```", str, re.DOTALL)
-    return sorted(matches, key=lambda x: len(x))[-1].strip()
+    try:
+        return sorted(matches, key=lambda x: len(x))[-1].strip()
+    except IndexError:
+        return None
+    except Exception as e:
+        print(e)
+        return None
 
 
 def contains_json(str):


### PR DESCRIPTION
This pull request addresses a bug in the extract block function that causes an error when selecting with an index in an empty list.